### PR TITLE
Improve handling of github token

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -32,7 +32,7 @@ runs:
         else
           mkdir ${{ inputs.tf_plan_directory }}
         fi
-      
+
     - name: Wait for checks to complete
       shell: bash
       if:  ${{ inputs.tf_api_token != '' }}
@@ -59,7 +59,6 @@ runs:
         docker run --rm \
           -v "$(pwd)/${{ inputs.tf_plan_directory }}:/data/${{ inputs.tf_plan_directory }}" \
           -e RESOURCELY_API_TOKEN="${{ inputs.resourcely_api_token }}" \
-          -e GITHUB_TOKEN="${{ inputs.gh_access_token }}" \
           ghcr.io/resourcely-inc/resourcely-cli:latest evaluate \
           --api_host "${{ inputs.resourcely_api_host }}" \
           --vcs github \


### PR DESCRIPTION
## What?

- Do not pass the github access token to `resourcely-cli`, which doesn't use it.
- ~Use the `github.token` context as the default for the github access token.~