### PR TITLE
readme improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,10 +9,6 @@ on:
   pull_request:
     branches: [ main ]
 
-permissions:
-  contents: read
-  packages: read
-
 # Define jobs to be run
 jobs:
   resourcely-ci:
@@ -43,10 +39,6 @@ on:
   pull_request:
     branches: [ main ]
 
-permissions:
-  contents: read
-  packages: read
-
 # Define jobs to be run
 jobs:
   resourcely-ci:
@@ -69,10 +61,6 @@ on:
     branches: [ main ]
   pull_request:
     branches: [ main ]
-
-permissions:
-  contents: read
-  packages: read
 
 # Define jobs to be run
 jobs:
@@ -99,10 +87,6 @@ on:
     branches: [ main ]
   pull_request:
     branches: [ main ]
-
-permissions:
-  contents: read
-  packages: read
 
 # Define jobs to be run
 jobs:

--- a/README.md
+++ b/README.md
@@ -7,8 +7,6 @@ For Resourcely to access Terraform Cloud and retrieve the Terraform plan, enabli
 ```   
 # Trigger conditions for running this action
 on:
-  push:
-    branches: [ main ]
   pull_request:
     branches: [ main ]
 
@@ -53,6 +51,7 @@ permissions:
 # Define jobs to be run
 jobs:
   resourcely-ci:
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
       - uses: Resourcely-Inc/resourcely-action@v1 # import the action
@@ -79,6 +78,7 @@ permissions:
 # Define jobs to be run
 jobs:
   resourcely-ci:
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
       - uses: Resourcely-Inc/resourcely-action@v1 # import the action
@@ -108,6 +108,7 @@ permissions:
 # Define jobs to be run
 jobs:
   resourcely-ci:
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
       - uses: Resourcely-Inc/resourcely-action@v1 # import the action

--- a/README.md
+++ b/README.md
@@ -22,8 +22,6 @@ jobs:
           tf_api_token: ${{ secrets.TF_API_TOKEN }}
           # grab the resourcely api token stored in the repo secrets
           resourcely_api_token: ${{ secrets.RESOURCELY_API_TOKEN }}
-          # set the resourcely api host
-          resourcely_api_host: "https://api.resourcely.io"
 ```
 
 
@@ -49,8 +47,6 @@ jobs:
         with:
           # grab the resourcely api token stored in the repo secrets
           resourcely_api_token: ${{ secrets.RESOURCELY_API_TOKEN }}
-          # set the resourcely api host
-          resourcely_api_host: "https://api.resourcely.io"
 ```
 
 You can set Pattern for Terraform plan files (e.g., plan*). Default Value: plan*
@@ -72,8 +68,6 @@ jobs:
         with:
           # grab the resourcely api token stored in the repo secrets
           resourcely_api_token: ${{ secrets.RESOURCELY_API_TOKEN }}
-          # set the resourcely api host
-          resourcely_api_host: "https://api.resourcely.io"
           # set terraform plan file name
           tf_plan_pattern: "plan"
 ```
@@ -98,9 +92,6 @@ jobs:
         with:
           # grab the resourcely api token stored in the repo secrets
           resourcely_api_token: ${{ secrets.RESOURCELY_API_TOKEN }}
-          # set the resourcely api host
-          resourcely_api_host: "https://api.resourcely.io"
           # set the tf directory for resourcely-action to read plan files from
           tf_plan_directory: "my-custom-directory"
 ```
-

--- a/README.md
+++ b/README.md
@@ -1,10 +1,9 @@
-
 ***There are two options available:***
 
 **Terraform Cloud**
 
 For Resourcely to access Terraform Cloud and retrieve the Terraform plan, enabling evaluation of your plans and policies with each pull request, configure the resourcely-action using the settings provided. For additional guidance, including instructions on creating an access token, please refer to the [Resourcely documentation](https://docs.resourcely.com/getting-started/onboarding/ci-cd-setup/github-actions/terraform-cloud)
-```   
+```
 # Trigger conditions for running this action
 on:
   pull_request:

--- a/action.yml
+++ b/action.yml
@@ -11,8 +11,9 @@ inputs:
     description: 'api to access resourcely api'
     required: true
   resourcely_api_host:
-    description: 'url for the resoucely api'
-    required: true
+    description: 'url for the resourcely api'
+    required: false
+    default: "https://api.resourcely.io"
   tf_plan_directory:
     description: 'directory to hold all the terraform plan'
     required: false


### PR DESCRIPTION
### What??

Update examples in the README to current best practice:

- use `github.token` instead of a PAT from `secrets
- do not run `resourcely-action` on pushes to `main` branch.