### PR TITLE
Set default value for `resourcely_api_host` input

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,6 @@ jobs:
           tf_api_token: ${{ secrets.TF_API_TOKEN }}
           # grab the resourcely api token stored in the repo secrets
           resourcely_api_token: ${{ secrets.RESOURCELY_API_TOKEN }}
-          # set the resourcely api host
-          resourcely_api_host: "https://api.resourcely.io"
 ```
 
 
@@ -56,8 +54,6 @@ jobs:
         with:
           # grab the resourcely api token stored in the repo secrets
           resourcely_api_token: ${{ secrets.RESOURCELY_API_TOKEN }}
-          # set the resourcely api host
-          resourcely_api_host: "https://api.resourcely.io"
 ```
 
 You can set Pattern for Terraform plan files (e.g., plan*). Default Value: plan*
@@ -83,8 +79,6 @@ jobs:
         with:
           # grab the resourcely api token stored in the repo secrets
           resourcely_api_token: ${{ secrets.RESOURCELY_API_TOKEN }}
-          # set the resourcely api host
-          resourcely_api_host: "https://api.resourcely.io"
           # set terraform plan file name
           tf_plan_pattern: "plan"
 ```
@@ -113,9 +107,6 @@ jobs:
         with:
           # grab the resourcely api token stored in the repo secrets
           resourcely_api_token: ${{ secrets.RESOURCELY_API_TOKEN }}
-          # set the resourcely api host
-          resourcely_api_host: "https://api.resourcely.io"
           # set the tf directory for resourcely-action to read plan files from
           tf_plan_directory: "my-custom-directory"
 ```
-

--- a/action.yml
+++ b/action.yml
@@ -12,8 +12,9 @@ inputs:
     description: 'api to access resourcely api'
     required: true
   resourcely_api_host:
-    description: 'url for the resoucely api'
-    required: true
+    description: 'url for the resourcely api'
+    required: false
+    default: "https://api.resourcely.io"
   tf_plan_directory:
     description: 'directory to hold all the terraform plan'
     required: false


### PR DESCRIPTION
### What?

Provide `https://api.resourcely.io` as the default value for `resourcely_api_host` and update the README examples accordingly.

### Why?

That's always the right value for our customers.  There is no need to clutter their workflow configs with it or give them the change to accidentally mess it up.
