### PR TITLE
use the manifest if it exists

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -61,7 +61,7 @@ runs:
       run: |
         docker pull ghcr.io/resourcely-inc/resourcely-cli:${{ inputs.docker_tag }}
         PLANS_ARGS=""
-        if [[ "${{ inputs.tf_api_token }}" != "" ]]; then
+        if [[ -f ${{ inputs.tf_plan_directory }}/manifest.json ]]; then
           PLANS_ARGS="--plan_manifest /data/tf-plan-files/manifest.json"
         else
           PLANS_ARGS=$(ls -1 ${{ inputs.tf_plan_directory }}/${{ inputs.tf_plan_pattern }} | xargs -I tok basename tok | sed "s|^|--plan /data/tf-plan-files/|" | tr '\n' ' ')


### PR DESCRIPTION
# What?
Use the manifest if it exists (old behavior: if you didn't give a TF token).

# Why?
Allows non-tf-token-users to pass in a mainfest.