### PR TITLE
Set --log debug when the action runs with debug output enabled

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -83,4 +83,5 @@ runs:
           ghcr.io/resourcely-inc/resourcely-cli:${{ inputs.docker_tag }} evaluate \
           --api_host "${{ inputs.resourcely_api_host }}" \
           --change_request_url "${{ github.event.pull_request.html_url }}" \
-          --change_request_sha "${{ github.event.pull_request.head.sha }}" $PLANS_ARGS
+          --change_request_sha "${{ github.event.pull_request.head.sha }}" $PLANS_ARGS \
+          --log ${{ runner.debug == '1' && 'debug' || 'info' }}


### PR DESCRIPTION
# What?
Tie `resourcely-cli` debug logging to GitHub debug logging like so:

![image](https://github.com/Resourcely-Inc/resourcely-action/assets/137814572/4d132f3a-c6d6-47d0-8479-e497a758d55b)

# Why?
Users should be able to turn on our debug logging without editing any yaml.

# Testing?
Manual. Here is a [run without debug logging](https://github.com/Resourcelypilot/integ-tests-dev/actions/runs/9280963921/job/25536202256) and here is a [run with debug logging](https://github.com/Resourcelypilot/integ-tests-dev/actions/runs/9280963921/job/25536578239#step:3:1437). Each link points directly to the line containing `--log <info|debug>`.